### PR TITLE
remove docker compose timeout

### DIFF
--- a/reconfig.sh
+++ b/reconfig.sh
@@ -14,4 +14,4 @@ docker-compose stop webconfig
 docker-compose stop sfmapp
 docker-compose stop lentilapp
 docker-compose stop combinedb
-docker-compose up -d --timeout 300
+docker-compose up -d


### PR DESCRIPTION
"docker-compose up" can't be run with both the --timeout and -d options at the same time in 1.18.0 (as seen here: https://github.com/docker/compose/pull/5435). This breaks the startup of the combine and causes the web application to be unreachable. This commit removes the timeout value.

This change to Docker compose will be reverted in 1.19.0 which seems like it will be released soon: https://github.com/docker/compose/pull/5565

So theoretically, this commit can be reverted when 1.19.0 is released too.

